### PR TITLE
Switch to AOSP Wallpaper Picker

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -23,7 +23,7 @@
     <string name="main_process_initializer_class" translatable="false">app.lawnchair.LawnchairProcessInitializer</string>
     <string name="task_overlay_factory_class" translatable="false">app.lawnchair.overview.TaskOverlayFactoryImpl</string>
     <string name="wallpaper_picker_package" translatable="false">com.android.wallpaper</string>
-    <string name="wallpaper_picker_package_alt" translatable="false">com.google.android.apps.wallpaper</string>
+    <string name="wallpaper_picker_package_alt" translatable="false">com.android.wallpaperpicker</string>
 
     <bool name="config_header_protection_supported">true</bool>
 


### PR DESCRIPTION
For tablets with 2-Pane layout, we need to use AOSP Wallpaper Picker to set wallpaper as it that can correctly zoom wallpapers.